### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ Cette application Streamlit permet de :
 
 Lancer en local :
 ```bash
-streamlit run analyse_smo2.py
+streamlit run analyse_smo2_zones_dynamique_v2.py
+```
+"""


### PR DESCRIPTION
## Summary
- close the bash block in README
- call out the new script name `analyse_smo2_zones_dynamique_v2.py`

## Testing
- `python3 -m py_compile analyse_smo2_zones_dynamique_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6841cb9349608331b43385e06b08d427